### PR TITLE
add seeds, active peers and total peers in the preload dialog

### DIFF
--- a/lib/navigation.py
+++ b/lib/navigation.py
@@ -474,6 +474,9 @@ def wait_for_buffering_completion(info_hash, file_id):
             status = api.get_torrent_file_info(info_hash, file_id)
             preloaded_bytes = status.get("preloaded_bytes", 0)
             preload_size = status.get("preload_size", 0)
+            seeds = status.get("connected_seeders", 0)
+            peers = status.get("active_peers", 0)
+            totalPeers = status.get("total_peers", 0)
 
             if preloaded_bytes != 0 and preload_size != 0:
                 if preloaded_bytes >= preload_size:
@@ -489,13 +492,14 @@ def wait_for_buffering_completion(info_hash, file_id):
 
             progress.update(
                 int(buffering_progress),
-                "{} - {:.2f}%\n{} {} {} - {}/s\n{}\n".format(
+                "{} - {:.2f}%\n{} {} {} - {}/s S:{} P:{}/{}\n{}\n".format(
                     get_state_string(status.get("stat")),
                     buffering_progress,
                     sizeof_fmt(preloaded_bytes),
                     of,
                     sizeof_fmt(preload_size),
                     sizeof_fmt(speed),
+                    seeds, peers, totalPeers,
                     name,
                 ),
             )

--- a/lib/navigation.py
+++ b/lib/navigation.py
@@ -476,7 +476,7 @@ def wait_for_buffering_completion(info_hash, file_id):
             preload_size = status.get("preload_size", 0)
             seeds = status.get("connected_seeders", 0)
             peers = status.get("active_peers", 0)
-            totalPeers = status.get("total_peers", 0)
+            total_peers = status.get("total_peers", 0)
 
             if preloaded_bytes != 0 and preload_size != 0:
                 if preloaded_bytes >= preload_size:
@@ -499,7 +499,9 @@ def wait_for_buffering_completion(info_hash, file_id):
                     of,
                     sizeof_fmt(preload_size),
                     sizeof_fmt(speed),
-                    seeds, peers, totalPeers,
+                    seeds,
+                    peers,
+                    total_peers,
                     name,
                 ),
             )


### PR DESCRIPTION
The update displays the number of seeds, active peers, and total peers right next to the download and upload speeds in the preload dialog.