### PR TITLE
Update play function to prevent subtitle scan

### DIFF
--- a/lib/navigation.py
+++ b/lib/navigation.py
@@ -563,7 +563,13 @@ def wait_for_buffering_completion(info_hash, file_id):
 def play(info_hash, file_id, path):
     name = path
     serve_url = api.get_stream_url(link=info_hash, path=name, file_id=file_id)
-    setResolvedUrl(plugin.handle, True, ListItem(name, path=serve_url))
+    list_item = ListItem(name, path=serve_url)
+    
+    # Prevent Kodi's synchronous pre-playback external-subtitle scan from opening
+    # the TorrServer stream URL. Kodi's GetParentPath keeps the ?link=&index= query,
+    # so the "directory" scan resolves to the media itself and stalls playback.
+    list_item.setProperty("no-ext-subs-scan", "true")
+    setResolvedUrl(plugin.handle, True, list_item)
 
     try:
         with JackTorrPlayer(


### PR DESCRIPTION
A bug in Kodi causes the subtitle scan to retain the media's query parameters resulting in the media being returned in torrservers response. Since there doesn't exist any kind of plain HTTP directory listing in torrserver, this can safely be disabled.

This bug was introduced in https://github.com/xbmc/xbmc/pull/28275 and is affecting nightly builds